### PR TITLE
Use extractBodyAsString

### DIFF
--- a/src/main/java/com/modus/camel/datasonnet/DatasonnetProcessor.java
+++ b/src/main/java/com/modus/camel/datasonnet/DatasonnetProcessor.java
@@ -17,6 +17,7 @@ import io.github.classgraph.ResourceList;
 import io.github.classgraph.ScanResult;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
+import org.apache.camel.support.MessageHelper;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,7 +199,7 @@ public class DatasonnetProcessor implements Processor {
         Document propertiesDocument = mapToDocument(exchange.getProperties());
         jsonnetVars.put("exchangeProperty", propertiesDocument);
 
-        Object body = (inputMimeType.contains("java") ? exchange.getMessage().getBody() : exchange.getMessage().getBody(java.lang.String.class));
+        Object body = (inputMimeType.contains("java") ? exchange.getMessage().getBody() : MessageHelper.extractBodyAsString(exchange.getMessage()));
 
         logger.debug("Input MIME type is " + inputMimeType);
         logger.debug("Output MIME type is: " + outputMimeType);

--- a/src/main/java/com/modus/camel/datasonnet/language/DatasonnetExpression.java
+++ b/src/main/java/com/modus/camel/datasonnet/language/DatasonnetExpression.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatasonnetExpression extends ExpressionAdapter implements GeneratedPropertyConfigurer {
-    private final String expression;
+    private String expression;
 
     private String inputMimeType;
     private String outputMimeType;
@@ -41,6 +41,7 @@ public class DatasonnetExpression extends ExpressionAdapter implements Generated
         try {
             if (innerExpression != null) {
                 String script = innerExpression.evaluate(exchange, String.class);
+                expression = script;
                 processor.setDatasonnetScript(script);
             }
             processor.setInputMimeType(getInputMimeType());


### PR DESCRIPTION
Ran into a bug when trying out datasonnet with the rest dsl. The request bodies come in as a StreamCache and consuming that with `getBody(String.class)` does not reset the stream. This helped method takes care of that.

The other commit is about setting the result of the outer expression in the expression field, this way the `toString` method will correctly show the expression that was attempted.